### PR TITLE
Fix crash when entity reference becomes invalid while disabled

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -52,7 +52,7 @@ function process_tick()
 	local current_tick = game.tick
 	for i = #global.disabledEntities, 1, -1 do -- Loop over table backwards because some entries get removed within the loop
 		local entity = global.disabledEntities[i][1]
-		if not (entity or entity.valid) then
+		if not (entity and entity.valid) then
 			table.remove(global.disabledEntities, i)
 		elseif global.disabledEntities[i][2] == current_tick then
 			entity.active = true


### PR DESCRIPTION
Wrong if condition was leading to attempts to operate on entities which
were themselves were truthy but were no longer valid, leading to game
crashes.
